### PR TITLE
Cpreprocessor parser

### DIFF
--- a/cmake/numpyeigenTools.cmake
+++ b/cmake/numpyeigenTools.cmake
@@ -1,6 +1,11 @@
 set(NPE_SRC_DIR ${CMAKE_CURRENT_SOURCE_DIR}/src)
 
 function(npe_add_module target_name)
+  find_program(CPP_PROGRAM, cpp)
+  if (NOT ${CPP_PROGRAM})
+    error("Could not find C preprocessor binary `cpp`. This is required to generate bindings!")
+  endif()
+
   execute_process(COMMAND python -c "import numpy as np;import sys;sys.stdout.write(np.get_include())"
     OUTPUT_VARIABLE NP_INCLUDE_DIR)
   execute_process(

--- a/cmake/numpyeigenTools.cmake
+++ b/cmake/numpyeigenTools.cmake
@@ -2,8 +2,15 @@ set(NPE_SRC_DIR ${CMAKE_CURRENT_SOURCE_DIR}/src)
 
 function(npe_add_module target_name)
   find_program(CPP_PROGRAM, cpp)
-  if (NOT ${CPP_PROGRAM})
-    error("Could not find C preprocessor binary `cpp`. This is required to generate bindings!")
+
+  if (MSVC)
+    set(C_PREPROCESSOR_CMD "${CMAKE_CXX_COMPILER} /E")
+  else()
+    find_program(cpp, FIND_CPP)
+    if (NOT ${FIND_CPP})
+      error("Failed to find C preprocessor. This is needed to generate bindings!")
+    endif()
+    set(C_PREPROCESSOR_CMD "cpp")
   endif()
 
   execute_process(COMMAND python -c "import numpy as np;import sys;sys.stdout.write(np.get_include())"
@@ -24,7 +31,7 @@ function(npe_add_module target_name)
     set(bound_function_source_filename "${CMAKE_CURRENT_BINARY_DIR}/${name}.out.cpp")
     add_custom_command(OUTPUT ${bound_function_source_filename}
       DEPENDS ${binding_source} ${NPE_SRC_DIR}/codegen_function.py ${NPE_SRC_DIR}/codegen_module.py
-      COMMAND python ${NPE_SRC_DIR}/codegen_function.py ${binding_source} -o ${bound_function_source_filename}
+      COMMAND python ${NPE_SRC_DIR}/codegen_function.py ${binding_source} ${C_PREPROCESSOR_CMD} -o ${bound_function_source_filename}
       WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 
     list(APPEND function_sources "${bound_function_source_filename}")

--- a/src/codegen_function.py
+++ b/src/codegen_function.py
@@ -275,6 +275,14 @@ def parse_end_code_statement(line, line_number):
     parse_eol_token(line.strip(), line_number=line_number)
 
 
+def parse_identifier(line, line_number):
+    pass
+
+
+def parse_type_expression(line, line_number):
+    pass
+
+
 def parse_binding_init_statement(line, line_number):
     global BINDING_INIT_TOKEN
 

--- a/src/codegen_function.py
+++ b/src/codegen_function.py
@@ -394,7 +394,6 @@ def validate_frontend_output():
             input_variable_meta[var_name].is_sparse = is_sparse_type(input_type_groups[group_idx][0])
 
 
-PUBLIC_ID_PREFIX = "NPE_PY_TYPE_"
 PRIVATE_ID_PREFIX = "_NPE_PY_BINDING_"
 PRIVATE_NAMESPACE = "npe::detail"
 TYPE_STRUCT_PUBLIC_NAME = "npe"
@@ -410,6 +409,9 @@ STORAGE_ORDER_SUFFIX_XM = STORAGE_ORDER_SUFFIXES[2]
 STORAGE_ORDER_CM = "ColMajor"
 STORAGE_ORDER_RM = "RowMajor"
 STORAGE_ORDER_XM = "NoOrder"
+MAP_TYPE_PREFIX = "npe_Map_"
+MATRIX_TYPE_PREFIX = "npe_Matrix_"
+SCALAR_TYPE_PREFIX = "npe_Scalar_"
 
 
 def has_numpy_types():
@@ -443,10 +445,6 @@ def storage_order_var(var_name):
 
 def type_id_var(var_name):
     return PRIVATE_ID_PREFIX + var_name + "_t_id"
-
-
-def type_struct_name(var_name):
-    return PUBLIC_ID_PREFIX + var_name
 
 
 def is_sparse_type(type_name):
@@ -503,9 +501,9 @@ def write_header(out_file):
     out_file.write("#include <numpy/arrayobject.h>\n")
     out_file.write("#include <pybind11/eigen.h>\n")
     out_file.write("#include <pybind11/numpy.h>\n")
-    out_file.write("#include \"npe_typedefs.h\"\n")
-    out_file.write("#include \"npe_utils.h\"\n")
-    out_file.write("#include \"sparse_array.h\"\n")
+    out_file.write("#include <npe_typedefs.h>\n")
+    out_file.write("#include <npe_utils.h>\n")
+    out_file.write("#include <sparse_array.h>\n")
     out_file.write("#include <Eigen/Sparse>\n")
     out_file.write(preamble_source_code + "\n")
 
@@ -620,7 +618,7 @@ def write_code_block(out_file, combo):
     template_str = "<"
     for var_name, var_meta in input_variable_meta.items():
         if var_name in input_varname_to_group:
-            template_str += "Map_" + var_name + ", Matrix_" + var_name + ","
+            template_str += "Map_" + var_name + ", Matrix_" + var_name + ", Scalar_" + var_name + ","
     template_str = template_str[:-1] + ">("
 
     call_str = call_str + template_str if has_numpy_types() else call_str + "("
@@ -645,8 +643,9 @@ def write_code_function_definition(out_file):
     template_str = "template <"
     for arg_name, arg_meta in input_variable_meta.items():
         if arg_name in input_varname_to_group:
-            template_str += "typename Type_%s," % arg_name
-            template_str += "typename Matrix_%s," % arg_name
+            template_str += "typename " + MAP_TYPE_PREFIX + arg_name + ","
+            template_str += "typename " + MATRIX_TYPE_PREFIX + arg_name + ","
+            template_str += "typename " + SCALAR_TYPE_PREFIX + arg_name + ","
     template_str = template_str[:-1] + ">\n"
     if has_numpy_types():
         out_file.write(template_str)
@@ -655,7 +654,7 @@ def write_code_function_definition(out_file):
     argument_str = ""
     for arg_name, arg_meta in input_variable_meta.items():
         if arg_name in input_varname_to_group:
-            argument_str += "Type_%s %s," % (arg_name, arg_name)
+            argument_str += "%s%s %s," % (MAP_TYPE_PREFIX, arg_name, arg_name)
         else:
             arg_meta: VariableMetadata = arg_meta
             argument_str += arg_meta.name_or_type[0] + " " + arg_name + ","

--- a/src/npe.h
+++ b/src/npe.h
@@ -2,10 +2,11 @@
 #define NPE_H
 
 #include <npe_utils.h>
+#include <npe_typedefs.h>
 
 // We define a bunch of stuff to make your ide work with npe_* syntax and produce valid types.
 // When we actually generate the bindings all of this is gone
-#ifndef NPE_FOR_REAL
+#ifndef __NPE_FOR_REAL__
 #define __NPE_GET_FIRST(arg, ...) arg
 #define __NPE_MATRIX_TYPE(arg, ...) npe_Matrix_##arg
 #define __NPE_MAP_TYPE(arg, ...) npe_Map_##arg
@@ -30,6 +31,6 @@ typedef Eigen::Map<matrix_dense_f64, Eigen::Aligned> dense_f64;
   npe::detail::__NPE_GET_FIRST(__VA_ARGS__) name;
 #define npe_begin_code()
 #define npe_end_code() }
-#endif // NPE_NOT_FOR_REAL
+#endif // __NPE_FOR_REAL__
 
 #endif // NPE_H

--- a/tests/binding_example.cpp
+++ b/tests/binding_example.cpp
@@ -1,27 +1,27 @@
 #include <tuple>
 #include <Eigen/Core>
-#include "npe_utils.h"
+#include <npe.h>
 
 // This defines a function named 'test_binding' which will be exposed to python
-npe_function("test_binding")
+npe_function(test_binding)
 
 // This says test binding takes as input a dense Eigen matrix, 'a', which can have scalar
 // type dense_f32 (float) or dense_f64 (double).
 // The variable 'a' has type Eigen::Map with scalar matching one of the input types. This means
 // the corresponding Python function takes a numpy array whose dtype is float32 or float64
-npe_arg("a", "dense_f32", "dense_f64")
+npe_arg(a, dense_f32, dense_f64)
 
 // This is another input variable, 'b'. It's type is a matches() statement. In this case, the matches() says that the
 // type of 'b' must match the type of 'a'. matches() statements can only match to numpy overloaded variables.
-npe_arg("b", "matches(a)")
+npe_arg(b, matches(a))
 
 // Here is another variable 'c' and two variables whose types have to match it.
-npe_arg("c", "dense_i32", "dense_i64")
-npe_arg("d", "matches(c)")
-npe_arg("e", "matches(d)")
+npe_arg(c, dense_i32, dense_i64)
+npe_arg(d, matches(c))
+npe_arg(e, matches(d))
 
 // This is a non-numpy overloaded input parameter of type int.
-npe_arg("f", "int")
+npe_arg(f, int)
 
 // After this directive is the actual source code of the bound function
 npe_begin_code()

--- a/tests/binding_example.cpp
+++ b/tests/binding_example.cpp
@@ -29,8 +29,8 @@ npe_begin_code()
 
 // We compute some return values using the types specified in the input. So, for example,
 // if you pass in matrices of doubles, you get the result as a matrix of doubles
-Matrix_a ret1 = a + b;
-Matrix_c ret2 = c + d + e * f;
+npe_Matrix_a ret1 = a + b;
+npe_Matrix_c ret2 = c + d + e * f;
 
 // MOVE_TO_NP returns a pybind11::array which takes ownership of the Eigen::Matrix passed as a second argument.
 // The first argument is the type of the Eigen::Matrix

--- a/tests/default_arg.cpp
+++ b/tests/default_arg.cpp
@@ -1,12 +1,11 @@
-
 #include <iostream>
 #include <tuple>
-#include <npe_utils.h>
+#include <npe.h>
 
-npe_function("default_arg")
-npe_arg("a", "dense_f64")
-npe_default_arg("b", "std::string", "std::string(\"abc\")")
-npe_default_arg("c", "dense_f64", "dense_f32", "pybind11::array_t<double>()")
+npe_function(default_arg)
+npe_arg(a, dense_f64)
+npe_default_arg(b, std::string, std::string("abc"))
+npe_default_arg(c, dense_f64, dense_f32, pybind11::array_t<double>())
 npe_begin_code()
 
 a(0, 0) = 2.0;

--- a/tests/environment.yml
+++ b/tests/environment.yml
@@ -35,8 +35,8 @@ dependencies:
   - mkl_fft=1.0.1=py36h3010b51_0
   - mkl_random=1.0.1=py36h629b387_0
   - ncurses=6.1=hf484d3e_0
-  - numpy=1.14.5=py36hcd700cb_0
-  - numpy-base=1.14.5=py36hdbf6ddf_0
+  - numpy=1.14.5=py36h1b885b7_4
+  - numpy-base=1.14.5=py36hdbf6ddf_4
   - openssl=1.0.2o=h20670df_0
   - parso=0.2.1=py36_0
   - pcre=8.42=h439df22_0
@@ -66,5 +66,4 @@ dependencies:
   - wheel=0.31.1=py36_0
   - xz=5.2.4=h14c3975_4
   - zlib=1.2.11=ha838bed_2
-prefix: /home/francis/miniconda3/envs/numpyeigen
 

--- a/tests/matrix_add.cpp
+++ b/tests/matrix_add.cpp
@@ -7,7 +7,7 @@ npe_arg("a", "dense_f64", "dense_f32")
 npe_arg("b", "matches(a)")
 npe_begin_code()
 
-Matrix_a ret1 = a + b;
+npe_Matrix_a ret1 = a + b;
 
 return NPE_MOVE_DENSE(ret1);
 

--- a/tests/matrix_add.cpp
+++ b/tests/matrix_add.cpp
@@ -1,10 +1,10 @@
 #include <tuple>
 #include <Eigen/Core>
-#include <npe_utils.h>
+#include <npe.h>
 
-npe_function("matrix_add")
-npe_arg("a", "dense_f64", "dense_f32")
-npe_arg("b", "matches(a)")
+npe_function(matrix_add)
+npe_arg(a, dense_f64, dense_f32)
+npe_arg(b, matches(a))
 npe_begin_code()
 
 npe_Matrix_a ret1 = a + b;

--- a/tests/mutate_matrix.cpp
+++ b/tests/mutate_matrix.cpp
@@ -1,9 +1,9 @@
 #include <iostream>
 #include <Eigen/Core>
-#include <npe_utils.h>
+#include <npe.h>
 
-npe_function("mutate_matrix")
-npe_arg("a", "dense_f64", "dense_f32")
+npe_function(mutate_matrix)
+npe_arg(a, dense_f64, dense_f32)
 npe_begin_code()
 
 std::cout << "mutate_matrix()" << std::endl;

--- a/tests/mutate_sparse_matrix.cpp
+++ b/tests/mutate_sparse_matrix.cpp
@@ -2,10 +2,10 @@
 #include <Eigen/Core>
 #include <iostream>
 
-#include "npe_utils.h"
+#include <npe.h>
 
-npe_function("mutate_sparse_matrix")
-npe_arg("a", "sparse_f64", "sparse_f32")
+npe_function(mutate_sparse_matrix)
+npe_arg(a, sparse_f64, sparse_f32)
 npe_begin_code()
 
 a.coeffRef(0, 0) = 2.0;

--- a/tests/no_numpy.cpp
+++ b/tests/no_numpy.cpp
@@ -1,8 +1,8 @@
 #include <string>
-#include <npe_utils.h>
+#include <npe.h>
 
-npe_function("no_numpy")
-npe_arg("a", "std::string")
+npe_function(no_numpy)
+npe_arg(a, std::string)
 npe_begin_code()
 
 return a;

--- a/tests/sparse_matrix_add.cpp
+++ b/tests/sparse_matrix_add.cpp
@@ -9,7 +9,7 @@ npe_arg("a", "sparse_f64", "sparse_f32")
 npe_arg("b", "matches(a)")
 npe_begin_code()
 
-Matrix_a ret1 = a + b;
+npe_Matrix_a ret1 = a + b;
 
 return NPE_MOVE_SPARSE(ret1);
 

--- a/tests/sparse_matrix_add.cpp
+++ b/tests/sparse_matrix_add.cpp
@@ -2,11 +2,11 @@
 #include <Eigen/Core>
 #include <iostream>
 
-#include "npe_utils.h"
+#include <npe.h>
 
-npe_function("sparse_matrix_add")
-npe_arg("a", "sparse_f64", "sparse_f32")
-npe_arg("b", "matches(a)")
+npe_function(sparse_matrix_add)
+npe_arg(a, sparse_f64, sparse_f32)
+npe_arg(b, matches(a))
 npe_begin_code()
 
 npe_Matrix_a ret1 = a + b;

--- a/tests/sparse_matrix_passthru.cpp
+++ b/tests/sparse_matrix_passthru.cpp
@@ -10,7 +10,7 @@ npe_arg("b", "matches(a)")
 npe_begin_code()
 
 // This addition should have no effect which is what we test.
-Matrix_a ret1 = a + b;
+npe_Matrix_a ret1 = a + b;
 
 return NPE_MOVE_SPARSE(a);
 

--- a/tests/sparse_matrix_passthru.cpp
+++ b/tests/sparse_matrix_passthru.cpp
@@ -2,11 +2,11 @@
 #include <Eigen/Core>
 #include <iostream>
 
-#include "npe_utils.h"
+#include <npe.h>
 
-npe_function("sparse_matrix_passthru")
-npe_arg("a", "sparse_f64", "sparse_f32")
-npe_arg("b", "matches(a)")
+npe_function(sparse_matrix_passthru)
+npe_arg(a, sparse_f64, sparse_f32)
+npe_arg(b, matches(a))
 npe_begin_code()
 
 // This addition should have no effect which is what we test.

--- a/tests/test_npe_call_interface.py
+++ b/tests/test_npe_call_interface.py
@@ -1,12 +1,10 @@
-import unittest
-import sys
 import os
-import time
+import sys
+import unittest
 
 sys.path.append(os.getcwd())
 import numpy as np
 import numpyeigen_test as npe_test
-import numpyeigen_helpers as npe_helpers
 
 
 class TestNpeCallInterface(unittest.TestCase):


### PR DESCRIPTION
We no longer need to quote everything which is amazing!
Also fix a line number bug. 

Currently I use the binary `cpp` for the preprocessor which should be available on mac and linux. I use `msvc -E` on windows. I couldn't get `gcc -E` to work for some reason but this would be a nice way of doing things.