### PR TITLE
Fixing git url for pybind dependency

### DIFF
--- a/cmake/numpyeigenDownloadExternal.cmake
+++ b/cmake/numpyeigenDownloadExternal.cmake
@@ -35,7 +35,7 @@ endfunction()
 
 function(numpyeigen_download_pybind11)
     numpyeigen_download_project(pybind11
-        GIT_REPOSITORY https://github.com/fwilliams/pybind11/
+        GIT_REPOSITORY https://github.com/fwilliams/pybind11.git
         GIT_TAG        numpy-hacks
     )
 endfunction()


### PR DESCRIPTION
There appears to be an error in the git url for pybind11.

Running cmake version 3.16.4 on macOS 10.15.2

Error:
```
Cloning into 'pybind11'...
ERROR: Repository not found.
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
Cloning into 'pybind11'...
ERROR: Repository not found.
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
Cloning into 'pybind11'...
ERROR: Repository not found.
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
CMake Error at .cache/pybind11/pybind11-download-prefix/tmp/pybind11-download-gitclone.cmake:31 (message):
  Failed to clone repository: 'https://github.com/fwilliams/pybind11/'
```