### PR TITLE
Add support for NumPy 2.0.0 ABI changes

### DIFF
--- a/cmake/numpyeigenDownloadExternal.cmake
+++ b/cmake/numpyeigenDownloadExternal.cmake
@@ -35,7 +35,7 @@ endfunction()
 
 function(numpyeigen_download_pybind11)
     numpyeigen_download_project(pybind11
-        GIT_REPOSITORY https://github.com/fwilliams/pybind11.git
-        GIT_TAG        new_numpy_hacks_stable
+        GIT_REPOSITORY https://github.com/pybind/pybind11.git
+        GIT_TAG        v2.13.6
     )
 endfunction()

--- a/src/npe_dtype.h
+++ b/src/npe_dtype.h
@@ -81,46 +81,50 @@ public:
     template <typename T> static dtype of() {
         return pybind11::detail::npy_format_descriptor<typename std::remove_cv<T>::type>::dtype();
     }
-
+#if NPY_ABI_VERSION <  0x02000000
+#define NPE_ARRAY_DESCRIPTOR_PROXY pybind11::detail::array_descriptor_proxy
+#else
+#define NPE_ARRAY_DESCRIPTOR_PROXY pybind11::detail::array_descriptor2_proxy
+#endif
     /// Size of the data type in bytes.
     ssize_t itemsize() const {
-        return pybind11::detail::array_descriptor_proxy(m_ptr)->elsize;
+        return NPE_ARRAY_DESCRIPTOR_PROXY(m_ptr)->elsize;
     }
 
     /// Returns true for structured data types.
     bool has_fields() const {
-        return pybind11::detail::array_descriptor_proxy(m_ptr)->names != nullptr;
+        return NPE_ARRAY_DESCRIPTOR_PROXY(m_ptr)->names != nullptr;
     }
 
     /// Single-character type code.
     char kind() const {
-        return pybind11::detail::array_descriptor_proxy(m_ptr)->kind;
+        return NPE_ARRAY_DESCRIPTOR_PROXY(m_ptr)->kind;
     }
 
     /// Return the NumPy array type char
     char type() const {
-        return pybind11::detail::array_descriptor_proxy(m_ptr)->type;
+        return NPE_ARRAY_DESCRIPTOR_PROXY(m_ptr)->type;
     }
 
     char byteorder() const {
-        return pybind11::detail::array_descriptor_proxy(m_ptr)->byteorder;
+        return NPE_ARRAY_DESCRIPTOR_PROXY(m_ptr)->byteorder;
     }
 
     /// Return the NumPy array descr flags
     int flags() const {
-        return pybind11::detail::array_descriptor_proxy(m_ptr)->flags;
+        return NPE_ARRAY_DESCRIPTOR_PROXY(m_ptr)->flags;
     }
 
     int type_num() const {
-      return pybind11::detail::array_descriptor_proxy(m_ptr)->type_num;
+      return NPE_ARRAY_DESCRIPTOR_PROXY(m_ptr)->type_num;
     }
 
     int elsize() const {
-      return pybind11::detail::array_descriptor_proxy(m_ptr)->elsize;
+      return NPE_ARRAY_DESCRIPTOR_PROXY(m_ptr)->elsize;
     }
 
     int alignment() const {
-      return pybind11::detail::array_descriptor_proxy(m_ptr)->alignment;
+      return NPE_ARRAY_DESCRIPTOR_PROXY(m_ptr)->alignment;
     }
 private:
     static pybind11::object _dtype_from_pep3118() {

--- a/src/npe_typedefs.h
+++ b/src/npe_typedefs.h
@@ -278,7 +278,7 @@ inline char get_type_char(const pybind11::array & b)
     if (pybind11::isinstance<pybind11::array_t<std::int16_t>>(b)) { return char_short; }
     if (pybind11::isinstance<pybind11::array_t<bool>>(b)) { return char_bool; }
     // Return the .dtype().type() which not be a basic numeric type.
-    return b.dtype().type();
+    return b.dtype().char_();
 }
 
 enum StorageOrder {


### PR DESCRIPTION
This adds support for the NumPy 2.0.0 ABI which is necessary to use `numpyeigen` and `point-cloud-utils` with `numpy>= 2.0.0`. This is `numpyeigen` portion of the changes necessary to address https://github.com/fwilliams/point-cloud-utils/issues/99 in point_cloud_utils. The two relevant changes are

1. The underlying NumPy array descriptor has changed in NumPy 2.0.0 to become more encapsulated and extendable and thus we need to call the correct underlying pybind11 wrapper depending on the NumPy ABI version.
2. In NumPy 2.0.0, the writability and ownership of the array is inferred from the handle.

After these changes, the unittests pass with NumPy 2.2.4 whereas they used to fail, specifically in `test_sparse_binding`.