### PR TITLE
Fix breakages with NumPy v1.x.x

### DIFF
--- a/src/npe_dtype.h
+++ b/src/npe_dtype.h
@@ -82,7 +82,7 @@ public:
         return pybind11::detail::npy_format_descriptor<typename std::remove_cv<T>::type>::dtype();
     }
 #if NPY_ABI_VERSION <  0x02000000
-#define NPE_ARRAY_DESCRIPTOR_PROXY pybind11::detail::array_descriptor_proxy
+#define NPE_ARRAY_DESCRIPTOR_PROXY pybind11::detail::array_descriptor1_proxy
 #else
 #define NPE_ARRAY_DESCRIPTOR_PROXY pybind11::detail::array_descriptor2_proxy
 #endif

--- a/src/npe_sparse_array.h
+++ b/src/npe_sparse_array.h
@@ -169,33 +169,6 @@ public:
 // Casts an Eigen Sparse type to scipy csr_matrix or csc_matrix.
 // If given a base, the numpy array references the src data, otherwise it'll make a copy.
 // writeable lets you turn off the writeable flag for the array.
-#if NPY_ABI_VERSION  < 0x02000000
-template <typename Type, typename = enable_if_t<is_eigen_sparse<Type>::value>>
-handle eigen_sparse_array_cast(Type* src, handle parent = none(), bool writable = true) {
-  bool rowMajor = Type::Flags & Eigen::RowMajor;
-
-  array data = array(src->nonZeros(), src->valuePtr(), parent);
-  data.flags() &= ~detail::npy_api::NPY_ARRAY_OWNDATA_;
-
-  array indptr = array((rowMajor ? src->rows() : src->cols()) + 1, src->outerIndexPtr(), parent);
-  indptr.flags() &= ~detail::npy_api::NPY_ARRAY_OWNDATA_;
-
-  array indices = array(src->nonZeros(), src->innerIndexPtr(), parent);
-  indices.flags() &= ~detail::npy_api::NPY_ARRAY_OWNDATA_;
-
-  object sparse_module = module::import("scipy.sparse");
-  object matrix_type = sparse_module.attr(
-      rowMajor ? "csr_matrix" : "csc_matrix");
-
-  if (!writable) {
-    indices.flags() &= ~detail::npy_api::NPY_ARRAY_WRITEABLE_;
-    indptr.flags() &= ~detail::npy_api::NPY_ARRAY_WRITEABLE_;
-    data.flags() &= ~detail::npy_api::NPY_ARRAY_WRITEABLE_;
-  }
-  return matrix_type(std::make_tuple(data, indices, indptr),
-                     std::make_pair(src->rows(), src->cols()), "copy"_a=false).release();
-}
-#else
 template <typename Type, typename = enable_if_t<is_eigen_sparse<Type>::value>>
 handle eigen_sparse_array_cast(Type* src, handle parent = none()) {
   bool rowMajor = Type::Flags & Eigen::RowMajor;
@@ -211,7 +184,6 @@ handle eigen_sparse_array_cast(Type* src, handle parent = none()) {
   return matrix_type(std::make_tuple(data, indices, indptr),
                      std::make_pair(src->rows(), src->cols()), "copy"_a=false).release();
 }
-#endif
 
 template <typename Type, typename = enable_if_t<is_eigen_sparse<Type>::value>>
 handle eigen_encapsulate_sparse(Type* src) {


### PR DESCRIPTION
This fixes the upstream point-cloud-utils build breakages for wheels.

1. Need to use `array_descriptor1_proxy` explicitly since `array_descriptor_proxy` represents the latest common elements between the ABIs in pybind11
2. Writable/ownership flags in array wrappers are dependent on pybind11 version, as opposed to NumPy ABI.